### PR TITLE
Add ocamlinit file in each project

### DIFF
--- a/expr/andboolexpr/.ocamlinit
+++ b/expr/andboolexpr/.ocamlinit
@@ -1,0 +1,2 @@
+open AndboolexprLib.Main;;
+open AndboolexprLib.Ast;;

--- a/expr/arithexpr/.ocamlinit
+++ b/expr/arithexpr/.ocamlinit
@@ -1,0 +1,2 @@
+open ArithexprLib.Main;;
+open ArithexprLib.Ast;;

--- a/expr/boolexpr/.ocamlinit
+++ b/expr/boolexpr/.ocamlinit
@@ -1,0 +1,2 @@
+open BoolexprLib.Main;;
+open BoolexprLib.Ast;;

--- a/expr/letarithexpr/.ocamlinit
+++ b/expr/letarithexpr/.ocamlinit
@@ -1,0 +1,2 @@
+open LetarithexprLib.Main;;
+open LetarithexprLib.Ast;;

--- a/expr/sarithexpr/.ocamlinit
+++ b/expr/sarithexpr/.ocamlinit
@@ -1,0 +1,2 @@
+open SarithexprLib.Main;;
+open SarithexprLib.Ast;;

--- a/expr/uarithexpr/.ocamlinit
+++ b/expr/uarithexpr/.ocamlinit
@@ -1,0 +1,2 @@
+open UarithexprLib.Main;;
+open UarithexprLib.Ast;;

--- a/expr/varboolexpr/.ocamlinit
+++ b/expr/varboolexpr/.ocamlinit
@@ -1,0 +1,2 @@
+open VarboolexprLib.Main;;
+open VarboolexprLib.Ast;;

--- a/lambda/church/.ocamlinit
+++ b/lambda/church/.ocamlinit
@@ -1,0 +1,2 @@
+open ChurchLib.Main;;
+open ChurchLib.Ast;;

--- a/lambda/untyped/.ocamlinit
+++ b/lambda/untyped/.ocamlinit
@@ -1,0 +1,2 @@
+open UntypedLib.Main;;
+open UntypedLib.Ast;;


### PR DESCRIPTION
It is convenient when testing to initialize the toplevel with Main and Ast definitions in scope and ready to use.